### PR TITLE
debian-dsc.bbclass: support fetching Files listed in .dsc

### DIFF
--- a/meta/classes/debian-dsc.bbclass
+++ b/meta/classes/debian-dsc.bbclass
@@ -13,6 +13,8 @@ python __anonymous() {
     dl_dir = d.getVar('DL_DIR', True) or ""
     dsc_file = (dsc_uri[0].split(";")[0]).split("/")[-1]
     filepath = dl_dir + '/' + dsc_file
+    repo = (dsc_uri[0].split(";")[0]).replace(dsc_file, "")
+    files = []
 
     # Parse .dsc for the important fields
     with open(filepath, 'r') as file:
@@ -22,12 +24,20 @@ python __anonymous() {
             if line.startswith('Version:'):
                 pv = line.split(": ")[-1].rstrip()
                 d.setVar('PV', pv)
+            elif line.startswith('Files:'):
+                line = file.readline()
+                while line and line.startswith(' '):
+                    f = line.split()[2]
+                    files.append(repo + f)
+                    line = file.readline()
                 break
             line = file.readline()
-
         file.close()
+    src_uri = d.getVar('SRC_URI', True) or ""
+    d.setVar('SRC_URI', src_uri + ' ' + ' '.join(files))
 
 # TODO:
-# 1. Get the name of tarball and set SRC_URI (lightweight dsc backend)
+# 1. Get the name of tarball and set SRC_URI (lightweight dsc backend) => Done
 # 2. Fetch tarball and derive 'debian/control' (full dsc backend)
+# 3. Extract fetched tarball and setup source tree
 }


### PR DESCRIPTION
Extension for debian-dsc.bbclass to fetch source tree and debian metadata based on downloaded .dsc file.
If possible, in future, pursing while loop should be replaced by calling back-end parser for debian control data implicitly used by Debian tools like dpkg-*.